### PR TITLE
Various additions and refactorings

### DIFF
--- a/money.cabal
+++ b/money.cabal
@@ -22,5 +22,8 @@ library
   build-depends:
     base >= 4.8
     , lens >= 4.11
+  if impl(ghc < 8)
+    build-depends:
+      semigroups >= 0.15
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/money.cabal
+++ b/money.cabal
@@ -19,6 +19,8 @@ library
   exposed-modules:     Data.Money
   -- other-modules:       
   other-extensions:    GeneralizedNewtypeDeriving
-  build-depends:       base >=4.8 && <4.9, lens >=4.11 && <4.12, text >=1.2 && <1.3, scientific >= 0.3 && <0.4
+  build-depends:
+    base >= 4.8
+    , lens >= 4.11
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/money.cabal
+++ b/money.cabal
@@ -18,7 +18,7 @@ cabal-version:       >=1.10
 library
   exposed-modules:     Data.Money
   -- other-modules:       
-  other-extensions:    OverloadedStrings, GeneralizedNewtypeDeriving, NoMonomorphismRestriction
+  other-extensions:    GeneralizedNewtypeDeriving
   build-depends:       base >=4.8 && <4.9, lens >=4.11 && <4.12, text >=1.2 && <1.3, scientific >= 0.3 && <0.4
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/src/Data/Money.hs
+++ b/src/Data/Money.hs
@@ -12,7 +12,7 @@ import Data.Semigroup (Semigroup, (<>))
 --
 --   Any num instances present are hidden, as multiplying money by money,
 --   for example, doesn't make any sense.
-newtype Money num = Money { getMoneySum :: (Sum num) }
+newtype Money num = Money (Sum num)
                     deriving (Semigroup, Monoid, Eq, Ord)
 
 instance Show num => Show (Money num) where

--- a/src/Data/Money.hs
+++ b/src/Data/Money.hs
@@ -4,7 +4,6 @@ module Data.Money where
 
 import Control.Lens (Lens, Getter, lens, Iso, iso, over, view, to)
 import Data.Monoid (Monoid, Sum(Sum, getSum), (<>))
-import Data.Scientific (Scientific)
 
 -- | A representation of monetary values.
 --   The monoid instance allows amounts of money to be added together.
@@ -15,10 +14,6 @@ newtype Money num = Money { getMoneySum :: (Sum num) }
 
 instance Show num => Show (Money num) where
   show m = '$': (show $ view getMoney m)
-
--- | Scientific numbers seem an appropriate default choice to represent
---   monetary values.
-type MoneyS = Money Scientific
 
 -- | 
 moneySum :: Iso (Money a) (Money b) (Sum a) (Sum b)

--- a/src/Data/Money.hs
+++ b/src/Data/Money.hs
@@ -18,10 +18,6 @@ newtype Money num = Money { getMoneySum :: (Sum num) }
 instance Show num => Show (Money num) where
   show m = '$': (show $ view getMoney m)
 
--- | 
-moneySum :: Iso (Money a) (Money b) (Sum a) (Sum b)
-moneySum = iso getMoneySum Money
-
 -- | The raw numeric value inside monetary value
 getMoney :: Iso (Money a) (Money b) a b
 getMoney = iso (\(Money a) -> a) Money . _Wrapped

--- a/src/Data/Money.hs
+++ b/src/Data/Money.hs
@@ -3,7 +3,7 @@
 module Data.Money
   (
     Money(Money)
-  , getMoney
+  , money
   , ($+$)
   , ($-$)
   , (*$)
@@ -29,11 +29,11 @@ newtype Money num = Money (Sum num)
                     deriving (Semigroup, Monoid, Eq, Ord)
 
 instance Show num => Show (Money num) where
-  show m = '$': (show $ view getMoney m)
+  show m = '$': (show $ view money m)
 
 -- | The raw numeric value inside monetary value
-getMoney :: Iso (Money a) (Money b) a b
-getMoney = iso (\(Money a) -> a) Money . _Wrapped
+money :: Iso (Money a) (Money b) a b
+money = iso (\(Money a) -> a) Money . _Wrapped
 
 infixl 6 $+$
 ($+$) :: Num a => Money a -> Money a -> Money a
@@ -41,11 +41,11 @@ infixl 6 $+$
 
 infixl 6 $-$
 ($-$) :: Num a => Money a -> Money a -> Money a
-($-$) n m = over getMoney (subtract (view getMoney m)) n
+($-$) n m = over money (subtract (view money m)) n
 
 infixr 7 *$
 (*$) :: Num a => a -> Money a -> Money a
-(*$) = over getMoney . (*)
+(*$) = over money . (*)
 
 infixl 7 $*
 ($*) :: Num a => Money a -> a -> Money a
@@ -53,21 +53,21 @@ infixl 7 $*
 
 infixl 7 $/
 ($/) :: Fractional a => Money a -> a -> Money a
-($/) m x = over getMoney (/x) m
+($/) m x = over money (/x) m
 
 infixl 7 $/$
 ($/$) :: Fractional a => Money a -> Money a -> a
-($/$) n m = view getMoney n / view getMoney m
+($/$) n m = view money n / view money m
 
 infixr 8 $^
 ($^) :: (Num a, Integral b) => Money a -> b -> Money a
-($^) m x = over getMoney (^x) m
+($^) m x = over money (^x) m
 
 infixr 8 $^^
 ($^^) :: (Fractional a, Integral b) => Money a -> b -> Money a
-($^^) m x = over getMoney (^^x) m
+($^^) m x = over money (^^x) m
 
 infixr 8 $**
 ($**) :: Floating a => Money a -> a -> Money a
-($**) m x = over getMoney (**x) m
+($**) m x = over money (**x) m
 

--- a/src/Data/Money.hs
+++ b/src/Data/Money.hs
@@ -9,6 +9,7 @@ module Data.Money
   , (*$)
   , ($*)
   , ($/)
+  , ($/$)
   , ($^)
   , ($^^)
   , ($**)
@@ -53,6 +54,10 @@ infixl 7 $*
 infixl 7 $/
 ($/) :: Fractional a => Money a -> a -> Money a
 ($/) m x = over getMoney (/x) m
+
+infixl 7 $/$
+($/$) :: Fractional a => Money a -> Money a -> a
+($/$) n m = view getMoney n / view getMoney m
 
 infixr 8 $^
 ($^) :: (Num a, Integral b) => Money a -> b -> Money a

--- a/src/Data/Money.hs
+++ b/src/Data/Money.hs
@@ -2,7 +2,7 @@
 
 module Data.Money where
 
-import Control.Lens (_Wrapped, Getter, Iso, iso, over, view, to)
+import Control.Lens (_Wrapped, Iso, iso, over, view)
 import Data.Monoid (Monoid, Sum(Sum))
 import Data.Semigroup (Semigroup, (<>))
 
@@ -25,13 +25,6 @@ moneySum = iso getMoneySum Money
 -- | The raw numeric value inside monetary value
 getMoney :: Iso (Money a) (Money b) a b
 getMoney = iso (\(Money a) -> a) Money . _Wrapped
-
-makeMoney_ :: a -> Money a
-makeMoney_ = Money . Sum
-
--- | Wrap a value into a monetary context
-makeMoney :: Getter a (Money a)
-makeMoney = to makeMoney_
 
 infixl 6 $+$
 ($+$) :: Num a => Money a -> Money a -> Money a

--- a/src/Data/Money.hs
+++ b/src/Data/Money.hs
@@ -1,6 +1,17 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
-module Data.Money where
+module Data.Money
+  (
+    Money(Money)
+  , getMoney
+  , ($+$)
+  , (*$)
+  , ($*)
+  , ($/)
+  , ($^)
+  , ($^^)
+  , ($**)
+  ) where
 
 import Control.Lens (_Wrapped, Iso, iso, over, view)
 import Data.Monoid (Monoid, Sum(Sum))

--- a/src/Data/Money.hs
+++ b/src/Data/Money.hs
@@ -3,14 +3,17 @@
 module Data.Money where
 
 import Control.Lens (Lens, Getter, lens, Iso, iso, over, view, to)
-import Data.Monoid (Monoid, Sum(Sum, getSum), (<>))
+import Data.Monoid (Monoid, Sum(Sum))
+import Data.Semigroup (Semigroup, (<>))
 
 -- | A representation of monetary values.
---   The monoid instance allows amounts of money to be added together.
---   Any num instances present are hidden, as dividing money by money,
+--
+--   The @Semigroup@ instance allows amounts of money to be added together.
+--
+--   Any num instances present are hidden, as multiplying money by money,
 --   for example, doesn't make any sense.
 newtype Money num = Money { getMoneySum :: (Sum num) }
-                    deriving (Monoid, Eq, Ord)
+                    deriving (Semigroup, Monoid, Eq, Ord)
 
 instance Show num => Show (Money num) where
   show m = '$': (show $ view getMoney m)

--- a/src/Data/Money.hs
+++ b/src/Data/Money.hs
@@ -5,6 +5,7 @@ module Data.Money
     Money(Money)
   , getMoney
   , ($+$)
+  , ($-$)
   , (*$)
   , ($*)
   , ($/)
@@ -36,6 +37,10 @@ getMoney = iso (\(Money a) -> a) Money . _Wrapped
 infixl 6 $+$
 ($+$) :: Num a => Money a -> Money a -> Money a
 ($+$) = (<>)
+
+infixl 6 $-$
+($-$) :: Num a => Money a -> Money a -> Money a
+($-$) n m = over getMoney (subtract (view getMoney m)) n
 
 infixr 7 *$
 (*$) :: Num a => a -> Money a -> Money a

--- a/src/Data/Money.hs
+++ b/src/Data/Money.hs
@@ -2,7 +2,7 @@
 
 module Data.Money where
 
-import Control.Lens (Lens, Getter, lens, Iso, iso, over, view, to)
+import Control.Lens (_Wrapped, Getter, Iso, iso, over, view, to)
 import Data.Monoid (Monoid, Sum(Sum))
 import Data.Semigroup (Semigroup, (<>))
 
@@ -23,9 +23,8 @@ moneySum :: Iso (Money a) (Money b) (Sum a) (Sum b)
 moneySum = iso getMoneySum Money
 
 -- | The raw numeric value inside monetary value
-getMoney :: Lens (Money a) (Money b) a b
-getMoney = lens (getSum . getMoneySum) setMon
-           where setMon (Money (Sum _)) z = (Money (Sum z))
+getMoney :: Iso (Money a) (Money b) a b
+getMoney = iso (\(Money a) -> a) Money . _Wrapped
 
 makeMoney_ :: a -> Money a
 makeMoney_ = Money . Sum


### PR DESCRIPTION
I went crazy with the refactoring mallet.

And by crazy I mean sane.  I did nice things to your library George.  With my mallet.

Most changes are uncontroversial.  The debatable changes include:

- removing access to the `Sum a`.  I have not found it useful so I removed it, but as suggest in the commit msgs if it is actually useful, I'd personally prefer to see a `Wrapped` instance.

- Rename `getMoney` (which was previously a `Lens`) to `money` (it is now an `Iso`).

There was previously a comment that  "dividing money by money is nonsense".  It is actually
quite useful, hence `($/$)`, and I changed the comment `s/dividing/multiplying/` which is... not as overtly false?  (related reading: https://math.stackexchange.com/questions/1236692/how-would-multiplying-money-work/1236772#1236772)